### PR TITLE
Upgrade wxWidgets to version 3.1.4

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,8 +1,8 @@
 class Wxmac < Formula
   desc     "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url      "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2"
-  sha256   "fffc1d34dac54ff7008df327907984b156c50cff5a2f36ee3da6052744ab554a"
+  url      "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.tar.bz2"
+  sha256   "3ca3a19a14b407d0cdda507a7930c2e84ae1c8e74f946e0144d2fa7d881f1a94"
   head     "https://github.com/wxWidgets/wxWidgets.git"
   bottle   :unneeded
 


### PR DESCRIPTION
wxWidgets 3.1.4 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.1.4/docs/readme.txt)