### PR TITLE
fix: Change salt timelib version dependency

### DIFF
--- a/Formula/salt.rb
+++ b/Formula/salt.rb
@@ -46,6 +46,11 @@ class Salt < Formula
     sha256 "de9421118a99c79cbba1e512d60e5caed1d63273ce30a0e8d4edef4a2e500387"
   end
 
+  patch do
+    url "https://github.com/cdalvaro/homebrew-tap/raw/master/formula-patches/salt/requirements-timelib-0.2.5.diff"
+    sha256 "343b13aabb43f5e54c9cd7381a0a3a57df702ef827347d7378fa15eb92b39ee2"
+  end
+
   def install
     ENV["SWIG_FEATURES"]="-I#{Formula["openssl@1.1"].opt_include}"
 

--- a/formula-patches/salt/requirements-timelib-0.2.5.diff
+++ b/formula-patches/salt/requirements-timelib-0.2.5.diff
@@ -1,0 +1,258 @@
+diff --git a/pkg/osx/req.txt b/pkg/osx/req.txt
+index d9ddab9dc1..e32696874d 100644
+--- a/pkg/osx/req.txt
++++ b/pkg/osx/req.txt
+@@ -27,5 +27,5 @@ pyzmq==19.0.0 ; python_version >= "3.8"
+ requests==2.21.0
+ setproctitle
+ six==1.14.0
+-timelib==0.2.4
++timelib==0.2.5
+ vultr==1.0.1
+diff --git a/pkg/windows/req.txt b/pkg/windows/req.txt
+index 6994a0421a..dc96a373bf 100644
+--- a/pkg/windows/req.txt
++++ b/pkg/windows/req.txt
+@@ -29,7 +29,7 @@ pyzmq==18.0.1 ; python_version < "3.8"
+ pyzmq==19.0.0 ; python_version >= "3.8"
+ requests==2.21.0
+ setproctitle
+-timelib==0.2.4
++timelib==0.2.5
+ wheel==0.33.4
+ 
+ # GitPython
+diff --git a/requirements/static/py3.5/darwin.txt b/requirements/static/py3.5/darwin.txt
+index 190750a657..9478e60ec7 100644
+--- a/requirements/static/py3.5/darwin.txt
++++ b/requirements/static/py3.5/darwin.txt
+@@ -115,7 +115,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.5/freebsd.txt b/requirements/static/py3.5/freebsd.txt
+index d5b2c73d25..4f3d8ea3a9 100644
+--- a/requirements/static/py3.5/freebsd.txt
++++ b/requirements/static/py3.5/freebsd.txt
+@@ -116,7 +116,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.5/linux.txt b/requirements/static/py3.5/linux.txt
+index 5a001e3132..5bb203cb39 100644
+--- a/requirements/static/py3.5/linux.txt
++++ b/requirements/static/py3.5/linux.txt
+@@ -208,7 +208,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.5/windows.txt b/requirements/static/py3.5/windows.txt
+index adf6981ec7..13a48d5f3c 100644
+--- a/requirements/static/py3.5/windows.txt
++++ b/requirements/static/py3.5/windows.txt
+@@ -108,7 +108,7 @@ six==1.12.0               # via cassandra-driver, cheroot, cherrypy, cryptograph
+ smmap2==2.0.5
+ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+ virtualenv==20.0.20
+diff --git a/requirements/static/py3.6/darwin.txt b/requirements/static/py3.6/darwin.txt
+index 4e994c9558..7f6c05864f 100644
+--- a/requirements/static/py3.6/darwin.txt
++++ b/requirements/static/py3.6/darwin.txt
+@@ -114,7 +114,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.6/freebsd.txt b/requirements/static/py3.6/freebsd.txt
+index 5a306de73d..03c3cc8b43 100644
+--- a/requirements/static/py3.6/freebsd.txt
++++ b/requirements/static/py3.6/freebsd.txt
+@@ -115,7 +115,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.6/linux.txt b/requirements/static/py3.6/linux.txt
+index 59a06bb503..4f36ee841c 100644
+--- a/requirements/static/py3.6/linux.txt
++++ b/requirements/static/py3.6/linux.txt
+@@ -207,7 +207,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.6/windows.txt b/requirements/static/py3.6/windows.txt
+index e8f5a76568..62d4ff001f 100644
+--- a/requirements/static/py3.6/windows.txt
++++ b/requirements/static/py3.6/windows.txt
+@@ -107,7 +107,7 @@ six==1.12.0               # via cassandra-driver, cheroot, cherrypy, cryptograph
+ smmap2==2.0.5
+ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+ virtualenv==20.0.20
+diff --git a/requirements/static/py3.7/darwin.txt b/requirements/static/py3.7/darwin.txt
+index d918020c18..b684eda874 100644
+--- a/requirements/static/py3.7/darwin.txt
++++ b/requirements/static/py3.7/darwin.txt
+@@ -112,7 +112,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.7/freebsd.txt b/requirements/static/py3.7/freebsd.txt
+index 000d1bb240..d41961dea5 100644
+--- a/requirements/static/py3.7/freebsd.txt
++++ b/requirements/static/py3.7/freebsd.txt
+@@ -114,7 +114,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.7/linux.txt b/requirements/static/py3.7/linux.txt
+index e7da619754..02ab8e3fb0 100644
+--- a/requirements/static/py3.7/linux.txt
++++ b/requirements/static/py3.7/linux.txt
+@@ -206,7 +206,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.7/windows.txt b/requirements/static/py3.7/windows.txt
+index a159d5124a..7505817131 100644
+--- a/requirements/static/py3.7/windows.txt
++++ b/requirements/static/py3.7/windows.txt
+@@ -105,7 +105,7 @@ six==1.12.0               # via cassandra-driver, cheroot, cherrypy, cryptograph
+ smmap2==2.0.5
+ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+ virtualenv==20.0.20
+diff --git a/requirements/static/py3.8/darwin.txt b/requirements/static/py3.8/darwin.txt
+index 8a7f2f7194..ef5fa590af 100644
+--- a/requirements/static/py3.8/darwin.txt
++++ b/requirements/static/py3.8/darwin.txt
+@@ -111,7 +111,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.8/freebsd.txt b/requirements/static/py3.8/freebsd.txt
+index 7665424346..a1f3551f90 100644
+--- a/requirements/static/py3.8/freebsd.txt
++++ b/requirements/static/py3.8/freebsd.txt
+@@ -113,7 +113,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.8/linux.txt b/requirements/static/py3.8/linux.txt
+index 10f39c7f5d..eba88756de 100644
+--- a/requirements/static/py3.8/linux.txt
++++ b/requirements/static/py3.8/linux.txt
+@@ -206,7 +206,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.9/darwin.txt b/requirements/static/py3.9/darwin.txt
+index b09bc6e064..ed89f03fd5 100644
+--- a/requirements/static/py3.9/darwin.txt
++++ b/requirements/static/py3.9/darwin.txt
+@@ -112,7 +112,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.9/freebsd.txt b/requirements/static/py3.9/freebsd.txt
+index 0607c62313..2f5f8f40a4 100644
+--- a/requirements/static/py3.9/freebsd.txt
++++ b/requirements/static/py3.9/freebsd.txt
+@@ -113,7 +113,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests
+diff --git a/requirements/static/py3.9/linux.txt b/requirements/static/py3.9/linux.txt
+index be8b1ac89a..ce25e457e2 100644
+--- a/requirements/static/py3.9/linux.txt
++++ b/requirements/static/py3.9/linux.txt
+@@ -206,7 +206,7 @@ strict-rfc3339==0.7
+ tempora==1.14.1           # via portend
+ terminal==0.4.0           # via ntc-templates
+ textfsm==1.1.0            # via ntc-templates
+-timelib==0.2.4
++timelib==0.2.5
+ toml==0.10.0
+ transitions==0.8.1        # via junos-eznc
+ urllib3==1.24.2           # via botocore, kubernetes, python-etcd, requests


### PR DESCRIPTION
Update `timelib` version from `0.2.4` to `0.2.5` (based on saltstack/salt#58341)

Solves issue installing `salt` with `python@3.7` (saltstack/salt#57742)