### PR TITLE
Upgrade cpp-jwt to version 1.4

### DIFF
--- a/Formula/cpp-jwt.rb
+++ b/Formula/cpp-jwt.rb
@@ -1,8 +1,8 @@
 class CppJwt < Formula
   desc     "JSON Web Token library for C++"
   homepage "https://github.com/arun11299/cpp-jwt"
-  url      "https://github.com/arun11299/cpp-jwt/archive/v1.3.tar.gz"
-  sha256   "792889f08dd1acbc14129d11e013f9ef46e663c545ea366dd922402d8becbe05"
+  url      "https://github.com/arun11299/cpp-jwt/archive/v1.4.tar.gz"
+  sha256   "1cb8039ee15bf9bf735c26082d7ff50c23d2886d65015dd6b0668c65e17dd20f"
   license  "MIT"
   head     "https://github.com/arun11299/cpp-jwt.git"
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ More documentation is available at: [Homebrew - Taps](https://docs.brew.sh/Taps)
 [homebrew_tap_badge]: https://img.shields.io/badge/brew%20tap-cdalvaro/tap-orange?style=flat-square&logo=Homebrew&color=FBB040
 [homebrew_tap_url]: https://github.com/cdalvaro/homebrew-tap
 [catboost_badge]: https://img.shields.io/badge/catboost-0.24.4-orange?style=flat-square&color=FBB040
-[cpp-jwt_badge]: https://img.shields.io/badge/cpp--jwt-1.3-orange?style=flat-square&color=FBB040
+[cpp-jwt_badge]: https://img.shields.io/badge/cpp--jwt-1.4-orange?style=flat-square&color=FBB040
 [cpp-plotly_badge]: https://img.shields.io/badge/cpp--plotly-0.4.0-orange?style=flat-square&color=FBB040
 [cpp-zmq_badge]: https://img.shields.io/badge/cpp--zmq-4.7.1-orange?style=flat-square&color=FBB040
 [howard-hinnant-date_badge]: https://img.shields.io/badge/howard--hinnant--date-3.0.0-orange?style=flat-square&color=FBB040


### PR DESCRIPTION
cpp-jwt 1.4 release notes are available [here](https://github.com/arun11299/cpp-jwt/releases/tag/v1.4).