### PR TITLE
Upgrade catboost to version 0.25.1

### DIFF
--- a/Formula/catboost.rb
+++ b/Formula/catboost.rb
@@ -1,8 +1,8 @@
 class Catboost < Formula
   desc "Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool"
   homepage "https://catboost.ai"
-  url "https://github.com/catboost/catboost/archive/v0.25.tar.gz"
-  sha256 "26c06716e7e235e5e837123be0251bacd23595b188d68194d88263e6ae56bf8f"
+  url "https://github.com/catboost/catboost/archive/v0.25.1.tar.gz"
+  sha256 "cfc5941dfe1b0bc827aa401702e61c2aa302613e7f68d42fee83e212712278da"
   license "Apache-2.0"
 
   livecheck do
@@ -17,13 +17,13 @@ class Catboost < Formula
   end
 
   resource "yandex-resources" do
-    url "https://storage.mds.yandex.net/get-devtools-opensource/233854/76eebdce3caf642db6f4ff3bbc441b41"
-    sha256 "add0f1c82e8c367c286486921a9e2a9378d241a2c6d9832cdcab678f009b6b07"
+    url "https://storage.mds.yandex.net/get-devtools-opensource/250854/e0789c39918157ef0786904445f7c9af"
+    sha256 "4a4e57756164e62d7032a2b2cddcc9e12cf04296ac358b32bcbc74a613da11f3"
   end
 
   resource "yandex" do
-    url "https://storage.mds.yandex.net/get-devtools-opensource/373962/2057406071"
-    sha256 "4dc49947ec9085228a804c73dbb0746fc9a035e59e4b45a74095a5474f34fde7"
+    url "https://storage.mds.yandex.net/get-devtools-opensource/373962/2086184410"
+    sha256 "2ca02a08ca0b0714428b8b38960933070786d7bbe35ddcc5cfc7672d44176f8d"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -32,16 +32,37 @@ brew tap cdalvaro/tap
 
 ## Available formulae
 
-| &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Formula &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Description                                                                                                                                                                                                                                                    |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![catboost][catboost_badge]](Formula/catboost.rb)                                                                                                                                                                                                                                                                                                                                                | [catboost/catboost](https://github.com/catboost/catboost) Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool                                                                                                                        |
-| [![cpp-jwt][cpp-jwt_badge]](Formula/cpp-jwt.rb)                                                                                                                                                                                                                                                                                                                                                   | [arun11299/cpp-jwt](https://github.com/arun11299/cpp-jwt) JSON Web Token library for C++                                                                                                                                                                       |
-| [![cpp-plotly][cpp-plotly_badge]](Formula/cpp-plotly.rb)                                                                                                                                                                                                                                                                                                                                          | [pablrod/cppplotly](https://github.com/pablrod/cppplotly) Generate html/javascript charts from C++ data using javascript library plotly.js                                                                                                                     |
-| [![cpp-zmq][cpp-zmq_badge]](Formula/cpp-zmq.rb)                                                                                                                                                                                                                                                                                                                                                   | [zeromq/cppzmq](https://github.com/zeromq/cppzmq) Header-only C++ binding for libzmq                                                                                                                                                                           |
-| [![howard-hinnant-date][howard-hinnant-date_badge]](Formula/howard-hinnant-date.rb)                                                                                                                                                                                                                                                                                                               | [HowardHinnant/date](https://github.com/HowardHinnant/date) A date and time library based on the C++11/14/17 <chrono> header                                                                                                                                   |
-| [![salt][salt_badge]](Formula/salt.rb)                                                                                                                                                                                                                                                                                                                                                            | [saltstack/salt](https://github.com/saltstack/salt) Software to automate the management and configuration of any infrastructure or application at scale. (Uses Python 3.7 to fix issue [saltstack/salt#57742](https://github.com/saltstack/salt/issues/57742)) |
-| [![simple-web-server][simple-web-server_badge]](Formula/simple-web-server.rb)                                                                                                                                                                                                                                                                                                                     | [eidheim/Simple-Web-Server](https://gitlab.com/eidheim/Simple-Web-Server) A very simple, fast, multithreaded, platform independent HTTP and HTTPS server and client library implemented using C++11 and Boost.Asio.                                            |
-| [![wxmac][wxmac_badge]](Formula/wxmac.rb)                                                                                                                                                                                                                                                                                                                                                         | [wxWidgets/wxWidgets](https://github.com/wxWidgets/wxWidgets) Cross-Platform GUI Library                                                                                                                                                                       |
+### [![catboost][catboost_badge]](Formula/catboost.rb "Catboost")
+
+[catboost/catboost](https://github.com/catboost/catboost) Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool.
+
+### [![cpp-jwt][cpp-jwt_badge]](Formula/cpp-jwt.rb "CppJwt")
+
+[arun11299/cpp-jwt](https://github.com/arun11299/cpp-jwt) JSON Web Token library for C++.
+
+### [![cpp-plotly][cpp-plotly_badge]](Formula/cpp-plotly.rb "CppPlotly")
+
+[pablrod/cppplotly](https://github.com/pablrod/cppplotly) Generate html/javascript charts from C++ data using javascript library plotly.js.
+
+### [![cpp-zmq][cpp-zmq_badge]](Formula/cpp-zmq.rb "CppZmq")
+
+[zeromq/cppzmq](https://github.com/zeromq/cppzmq) Header-only C++ binding for libzmq.
+
+### [![howard-hinnant-date][howard-hinnant-date_badge]](Formula/howard-hinnant-date.rb "HowardHinnantDate")
+
+[HowardHinnant/date](https://github.com/HowardHinnant/date) A date and time library based on the C++11/14/17 \<chrono\> header.
+
+### [![salt][salt_badge]](Formula/salt.rb "Salt")
+
+[saltstack/salt](https://github.com/saltstack/salt) Software to automate the management and configuration of any infrastructure or application at scale. (Uses Python 3.7 to fix issue [saltstack/salt#57742](https://github.com/saltstack/salt/issues/57742))
+
+### [![simple-web-server][simple-web-server_badge]](Formula/simple-web-server.rb "SimpleWebServer")
+
+[eidheim/Simple-Web-Server](https://gitlab.com/eidheim/Simple-Web-Server) A very simple, fast, multithreaded, platform independent HTTP and HTTPS server and client library implemented using C++11 and Boost.Asio.
+
+### [![wxmac][wxmac_badge]](Formula/wxmac.rb "WxMac")
+
+[wxWidgets/wxWidgets](https://github.com/wxWidgets/wxWidgets) Cross-Platform GUI Library.
 
 ## More Documentation
 
@@ -49,7 +70,7 @@ More documentation is available at: [Homebrew - Taps](https://docs.brew.sh/Taps)
 
 [homebrew_tap_badge]: https://img.shields.io/badge/brew%20tap-cdalvaro/tap-orange?style=flat-square&logo=Homebrew&color=FBB040
 [homebrew_tap_url]: https://github.com/cdalvaro/homebrew-tap
-[catboost_badge]: https://img.shields.io/badge/catboost-0.25-orange?style=flat-square&color=FBB040
+[catboost_badge]: https://img.shields.io/badge/catboost-0.25.1-orange?style=flat-square&color=FBB040
 [cpp-jwt_badge]: https://img.shields.io/badge/cpp--jwt-1.4-orange?style=flat-square&color=FBB040
 [cpp-plotly_badge]: https://img.shields.io/badge/cpp--plotly-0.4.0-orange?style=flat-square&color=FBB040
 [cpp-zmq_badge]: https://img.shields.io/badge/cpp--zmq-4.7.1-orange?style=flat-square&color=FBB040


### PR DESCRIPTION
catboost 0.25.1 release notes are available [here](https://github.com/catboost/catboost/releases/tag/v0.25.1).