### PR TITLE
Upgrade wxmac to version 3.1.5

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,10 +1,9 @@
 class Wxmac < Formula
   desc     "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url      "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.4/wxWidgets-3.1.4.tar.bz2"
-  sha256   "3ca3a19a14b407d0cdda507a7930c2e84ae1c8e74f946e0144d2fa7d881f1a94"
+  url      "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2"
+  sha256   "d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224"
   license  "wxWindows"
-  revision 1
   head     "https://github.com/wxWidgets/wxWidgets.git"
 
   livecheck do
@@ -43,15 +42,15 @@ class Wxmac < Formula
       "--enable-std_string",
       "--enable-svg",
       "--enable-unicode",
-      "--enable-webkit",
-      "--enable-webview",
+      "--enable-webviewwebkit",
       "--with-expat",
       "--with-libjpeg",
       "--with-libpng",
       "--with-libtiff",
       "--with-opengl",
-      "--with-osx_cocoa",
+      "--with-osx",
       "--with-zlib",
+      "--with-libcurl",
       "--disable-precomp-headers",
       # This is the default option, but be explicit
       "--disable-monolithic",

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ brew link cdalvaro/tap/salt@3002
 
 A very simple, fast, multithreaded, platform independent HTTP and HTTPS server and client library implemented using C++11 and Boost.Asio.
 
-### [wxWidgets/wxWidgets](https://github.com/wxWidgets/wxWidgets)<a href="Formula/wxmac.rb"><img src="https://img.shields.io/badge/wxmac-3.1.4-orange?style=flat-square&color=FBB040" align="right"/></a>
+### [wxWidgets/wxWidgets](https://github.com/wxWidgets/wxWidgets)<a href="Formula/wxmac.rb"><img src="https://img.shields.io/badge/wxmac-3.1.5-orange?style=flat-square&color=FBB040" align="right"/></a>
 
 Cross-Platform GUI Library.
 


### PR DESCRIPTION
wxWidgets 3.1.5 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.1.5/docs/readme.txt).