### PR TITLE
Upgrade catboost to version 0.26.1

### DIFF
--- a/Formula/catboost.rb
+++ b/Formula/catboost.rb
@@ -1,8 +1,8 @@
 class Catboost < Formula
   desc "Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool"
   homepage "https://catboost.ai"
-  url "https://github.com/catboost/catboost/archive/v0.25.1.tar.gz"
-  sha256 "cfc5941dfe1b0bc827aa401702e61c2aa302613e7f68d42fee83e212712278da"
+  url "https://github.com/catboost/catboost/archive/v0.26.1.tar.gz"
+  sha256 "a82971e13facc8421c14755bfc489be9a3d21f81ec529044db90a9b53cc32b01"
   license "Apache-2.0"
 
   livecheck do
@@ -14,16 +14,6 @@ class Catboost < Formula
     root_url "https://github.com/cdalvaro/homebrew-tap/releases/download/catboost-0.25.1"
     sha256 cellar: :any_skip_relocation, big_sur:  "faeddb0922d27bd63eecf3db006f967d88209dfe04a6a586b8a38da3b36c73f8"
     sha256 cellar: :any_skip_relocation, catalina: "2c1c3fd57e8fd9d53aca9e19c08a6192c52f51386c7da2e4920980ac3041bd55"
-  end
-
-  resource "yandex-resources" do
-    url "https://storage.mds.yandex.net/get-devtools-opensource/250854/e0789c39918157ef0786904445f7c9af"
-    sha256 "4a4e57756164e62d7032a2b2cddcc9e12cf04296ac358b32bcbc74a613da11f3"
-  end
-
-  resource "yandex" do
-    url "https://storage.mds.yandex.net/get-devtools-opensource/373962/2086184410"
-    sha256 "2ca02a08ca0b0714428b8b38960933070786d7bbe35ddcc5cfc7672d44176f8d"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can directly type `brew install cdalvaro/tap/<formula>` to install the speci
 
 ## Available formulae
 
-#### [catboost/catboost](https://github.com/catboost/catboost)<a href="Formula/catboost.rb"><img src="https://img.shields.io/badge/catboost-0.25.1-orange?style=flat-square&color=FBB040" align="right"/></a>
+#### [catboost/catboost](https://github.com/catboost/catboost)<a href="Formula/catboost.rb"><img src="https://img.shields.io/badge/catboost-0.26.1-orange?style=flat-square&color=FBB040" align="right"/></a>
 
 Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool.
 


### PR DESCRIPTION
catboost 0.26.1 release notes are available [here](https://github.com/catboost/catboost/releases/tag/v0.26.1).