### PR TITLE
Upgrade catboost-cli to version 1.0.0

### DIFF
--- a/Formula/catboost-cli.rb
+++ b/Formula/catboost-cli.rb
@@ -1,8 +1,8 @@
-class Catboost < Formula
+class CatboostCli < Formula
   desc "Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool"
   homepage "https://catboost.ai"
-  url "https://github.com/catboost/catboost/archive/v0.26.1.tar.gz"
-  sha256 "a82971e13facc8421c14755bfc489be9a3d21f81ec529044db90a9b53cc32b01"
+  url "https://github.com/catboost/catboost/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "376142fc7ceb07412d70d0cb2c5b21016f2b5d40667d3ea61873360497270acd"
   license "Apache-2.0"
 
   livecheck do

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can directly type `brew install cdalvaro/tap/<formula>` to install the speci
 
 ## Available formulae
 
-#### [catboost/catboost](https://github.com/catboost/catboost)<a href="Formula/catboost.rb"><img src="https://img.shields.io/badge/catboost-0.26.1-orange?style=flat-square&color=FBB040" align="right"/></a>
+#### [catboost/catboost](https://github.com/catboost/catboost)<a href="Formula/catboost.rb"><img src="https://img.shields.io/badge/catboost--cli-1.0.0-orange?style=flat-square&color=FBB040" align="right"/></a>
 
 Fast, scalable, high performance Gradient Boosting on Decision Trees cli tool.
 

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,4 +1,5 @@
 {
   "cppzmq": "cpp-zmq",
-  "salt@3002.6": "salt@3002"
+  "salt@3002.6": "salt@3002",
+  "catboost": "catboost-cli"
 }


### PR DESCRIPTION
catboost 1.0.0 release notes are available [here](https://github.com/catboost/catboost/releases/tag/v1.0.0).