### PR TITLE
Upgrade wxmac to version 3.1.6

### DIFF
--- a/Aliases/salt@3003
+++ b/Aliases/salt@3003
@@ -1,0 +1,1 @@
+../Formula/salt.rb

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,8 +1,8 @@
 class Wxmac < Formula
   desc     "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url      "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2"
-  sha256   "d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224"
+  url      "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxWidgets-3.1.6.tar.bz2"
+  sha256   "6a2339997794eb9964aa4e0985aa2b8614257d63bb5e422f8cd9363f0d376146"
   license  "wxWindows"
   head     "https://github.com/wxWidgets/wxWidgets.git"
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ brew link cdalvaro/tap/salt@3002
 
 A very simple, fast, multithreaded, platform independent HTTP and HTTPS server and client library implemented using C++11 and Boost.Asio.
 
-#### [wxWidgets/wxWidgets](https://github.com/wxWidgets/wxWidgets)<a href="Formula/wxmac.rb"><img src="https://img.shields.io/badge/wxmac-3.1.5-orange?style=flat-square&color=FBB040" align="right"/></a>
+#### [wxWidgets/wxWidgets](https://github.com/wxWidgets/wxWidgets)<a href="Formula/wxmac.rb"><img src="https://img.shields.io/badge/wxmac-3.1.6-orange?style=flat-square&color=FBB040" align="right"/></a>
 
 Cross-Platform GUI Library.
 


### PR DESCRIPTION
wxWidgets 3.1.6 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.1.6/docs/changes.txt).