### PR TITLE
Upgrade wxmac to version 3.2.1

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,8 +1,8 @@
 class Wxmac < Formula
   desc     "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.0/wxWidgets-3.2.0.tar.bz2"
-  sha256 "356e9b55f1ae3d58ae1fed61478e9b754d46b820913e3bfbc971c50377c1903a"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxWidgets-3.2.1.tar.bz2"
+  sha256 "c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66"
   license  "wxWindows"
   head     "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
 


### PR DESCRIPTION
wxWidgets 3.2.1 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.2.1/docs/changes.txt).

Use `wx-config --cxxflags --libs all` to check new compilation options.