### PR TITLE
Upgrade wxWidgets to version 3.2.2

### DIFF
--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -1,10 +1,10 @@
-class Wxmac < Formula
-  desc     "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
+class Wxwidgets < Formula
+  desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxWidgets-3.2.1.tar.bz2"
-  sha256 "c229976bb413eb88e45cb5dfb68b27890d450149c09b331abd751e7ae0f5fa66"
-  license  "wxWindows"
-  head     "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2/wxWidgets-3.2.2.tar.bz2"
+  sha256 "8edf18672b7bc0996ee6b7caa2bee017a9be604aad1ee471e243df7471f5db5d"
+  license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
+  head "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
 
   livecheck do
     url :stable
@@ -20,12 +20,16 @@ class Wxmac < Formula
 
   option "with-enable-abort", "apply patch patch-make-public-enable-abort"
 
-  depends_on "jpeg"
+  depends_on "pkg-config" => :build
+  depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "pcre2"
+
+  uses_from_macos "expat"
+  uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
     depends_on "gtk+3"
     depends_on "libsm"
     depends_on "mesa-glu"
@@ -39,6 +43,10 @@ class Wxmac < Formula
   end
 
   def install
+    # Remove all bundled libraries excluding `nanosvg` which isn't available as formula
+    %w[catch pcre].each { |l| (buildpath/"3rdparty"/l).rmtree }
+    %w[expat jpeg png tiff zlib].each { |l| (buildpath/"src"/l).rmtree }
+
     args = [
       "--prefix=#{prefix}",
       "--enable-clipboard",
@@ -56,25 +64,33 @@ class Wxmac < Formula
       "--with-libpng",
       "--with-libtiff",
       "--with-opengl",
-      "--with-osx",
       "--with-zlib",
-      "--with-libcurl",
+      "--disable-dependency-tracking",
+      "--disable-tests",
       "--disable-precomp-headers",
       # This is the default option, but be explicit
       "--disable-monolithic",
-      "--disable-tests",
-      # Set with-macosx-version-min to avoid configure defaulting to 10.5
-      "--with-macosx-version-min=#{MacOS.version}",
     ]
+
+    if OS.mac?
+      # Set with-macosx-version-min to avoid configure defaulting to 10.5
+      args << "--with-macosx-version-min=#{MacOS.version}"
+      args << "--with-osx_cocoa"
+      args << "--with-libiconv"
+    end
 
     system "./configure", *args
     system "make", "install"
 
-    # wx-config should reference the public prefix, not wxmac's keg
+    # wx-config should reference the public prefix, not wxwidgets's keg
     # this ensures that Python software trying to locate wxpython headers
-    # using wx-config can find both wxmac and wxpython headers,
+    # using wx-config can find both wxwidgets and wxpython headers,
     # which are linked to the same place
-    inreplace "#{bin}/wx-config", prefix, HOMEBREW_PREFIX
+    inreplace bin/"wx-config", prefix, HOMEBREW_PREFIX
+
+    # For consistency with the versioned wxwidgets formulae
+    bin.install_symlink bin/"wx-config" => "wx-config-#{version.major_minor}"
+    (share/"wx"/version.major_minor).install share/"aclocal", share/"bakefile"
   end
 
   test do


### PR DESCRIPTION
wxWidgets 3.2.2 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.2.2/docs/changes.txt).

Use `wx-config --cxxflags --libs all` to check new compilation options.