### PR TITLE
Upgrade wxWidgets to version 3.2.2.1

### DIFF
--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -1,8 +1,8 @@
 class Wxwidgets < Formula
   desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2/wxWidgets-3.2.2.tar.bz2"
-  sha256 "8edf18672b7bc0996ee6b7caa2bee017a9be604aad1ee471e243df7471f5db5d"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1.tar.bz2"
+  sha256 "dffcb6be71296fff4b7f8840eb1b510178f57aa2eb236b20da41182009242c02"
   license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
   head "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
 


### PR DESCRIPTION
wxWidgets 3.2.2.1 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.2.2.1/docs/changes.txt).

Use `wx-config --cxxflags --libs all` to check new compilation options.