### PR TITLE
cpp-zmq 4.10.0

### DIFF
--- a/Formula/cpp-zmq.rb
+++ b/Formula/cpp-zmq.rb
@@ -1,8 +1,8 @@
 class CppZmq < Formula
   desc     "Header-only C++ binding for libzmq"
   homepage "https://github.com/zeromq/cppzmq"
-  url      "https://github.com/zeromq/cppzmq/archive/v4.9.0.tar.gz"
-  sha256   "3fdf5b100206953f674c94d40599bdb3ea255244dcc42fab0d75855ee3645581"
+  url      "https://github.com/zeromq/cppzmq/archive/v4.10.0.tar.gz"
+  sha256   "c81c81bba8a7644c84932225f018b5088743a22999c6d82a2b5f5cd1e6942b74"
   license  "MIT"
   head     "https://github.com/zeromq/cppzmq.git"
 


### PR DESCRIPTION
cpp-zmq 4.10.0 release notes are available [here](https://github.com/zeromq/cppzmq/releases/tag/v4.10.0).