### PR TITLE
Upgrade wxWidgets to version 3.2.3

### DIFF
--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -1,8 +1,8 @@
 class Wxwidgets < Formula
   desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1.tar.bz2"
-  sha256 "dffcb6be71296fff4b7f8840eb1b510178f57aa2eb236b20da41182009242c02"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.3/wxWidgets-3.2.3.tar.bz2"
+  sha256 "c170ab67c7e167387162276aea84e055ee58424486404bba692c401730d1a67a"
   license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
   head "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
 


### PR DESCRIPTION
wxWidgets 3.2.3 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.2.3/docs/changes.txt).

Use `wx-config --cxxflags --libs all` to check new compilation options.