### PR TITLE
wxwidgets 3.2.4

### DIFF
--- a/Formula/wxwidgets.rb
+++ b/Formula/wxwidgets.rb
@@ -1,8 +1,8 @@
 class Wxwidgets < Formula
   desc "Cross-platform C++ GUI toolkit (wxWidgets for macOS)"
   homepage "https://www.wxwidgets.org"
-  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.3/wxWidgets-3.2.3.tar.bz2"
-  sha256 "c170ab67c7e167387162276aea84e055ee58424486404bba692c401730d1a67a"
+  url "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.4/wxWidgets-3.2.4.tar.bz2"
+  sha256 "0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e"
   license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
   head "https://github.com/wxWidgets/wxWidgets.git", branch: "master"
 


### PR DESCRIPTION
wxWidgets 3.2.4 release notes are available [here](https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.2.4/docs/changes.txt).

Use `wx-config --cxxflags --libs all` to check new compilation options.