### PR TITLE
chore(cask): update Salt to 3008.2

### DIFF
--- a/Casks/salt.rb
+++ b/Casks/salt.rb
@@ -1,11 +1,11 @@
 cask "salt" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "3008.1"
+  version "3008.2"
 
   on_macos do
-    sha256 arm:   "6358d1e76253b2894282992b1202a2b1f437a70a280c419ffde2707408fbce71",
-           intel: "78a467dee76eff9a5b58c63f588e69b703588a220aff269ed1b74b81d2818c35"
+    sha256 arm:   "9a227cd679b5ec276957e558bb0f87a014ee2b84bc72c70810494a7b8b73defa",
+           intel: "50affec75bc4036cc5d5424e49fee2d11b7daa4778afdabc58cd2b9cc3421b40"
   end
 
   on_linux do

--- a/Formula/boost@1.89.rb
+++ b/Formula/boost@1.89.rb
@@ -140,7 +140,7 @@ class BoostAT189 < Formula
       }
     CPP
     system ENV.cxx, "test.cpp", "-std=c++14", "-o", "test", "-I#{include}", "-L#{lib}", "-lboost_iostreams",
-                    "-L#{Formula["zstd"].opt_lib}", "-lzstd"
+                    "-L#{formula_opt_lib("zstd")}", "-lzstd"
     system "./test"
   end
 end

--- a/Formula/boost@1.89.rb
+++ b/Formula/boost@1.89.rb
@@ -33,6 +33,10 @@ class BoostAT189 < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
   # Fix for `ncmpcpp`, pr ref: https://github.com/boostorg/range/pull/157
   patch :p3 do
     url "https://github.com/boostorg/range/commit/9ac89e9936b826c13e90611cb9a81a7aa0508d20.patch?full_index=1"

--- a/Formula/cpp-plotly.rb
+++ b/Formula/cpp-plotly.rb
@@ -44,7 +44,7 @@ class CppPlotly < Formula
       }
     EOS
     system ENV.cxx, "-I#{include}", "-std=c++14",
-           "-L#{Formula["json11"].opt_lib}", "-ljson11",
+           "-L#{formula_opt_lib("json11")}", "-ljson11",
            "test.cpp", "-o", "test"
     system "./test"
   end

--- a/Formula/cpp-plotly.rb
+++ b/Formula/cpp-plotly.rb
@@ -4,7 +4,7 @@ class CppPlotly < Formula
   url      "https://github.com/pablrod/cppplotly/archive/refs/tags/v0.4.0.tar.gz"
   sha256   "378a978d5e6d06685e83593bbd5c4652685c2340240312ce57913befcca9f7c3"
   revision 2
-  head     "https://github.com/pablrod/cppplotly.git"
+  head     "https://github.com/pablrod/cppplotly.git", branch: "master"
 
   livecheck do
     url :stable


### PR DESCRIPTION
## Summary
- Update the `salt` cask to Salt 3008.2.
- Refresh the macOS arm64 and x86_64 package checksums.
- Apply current Homebrew audit/style fixes required by `brew test-bot`.
